### PR TITLE
Implement remaining Gusto domains

### DIFF
--- a/tomplot/data_extraction.py
+++ b/tomplot/data_extraction.py
@@ -61,9 +61,9 @@ def extract_gusto_coords(dataset, field_name, units=None):
             + f'spherical shell domain units must be "deg" or "rad" not {units}'
         if units is None:
             units = 'deg'
-    elif domain == 'vertical_slice':
+    elif domain in ['vertical_slice', 'plane', 'extruded_plane', 'interval']:
         assert units in [None, 'm', 'km'], 'extract_gusto_coords: for a ' \
-            + f'vertical slice domain units must be "m" or "km" not {units}'
+            + f'{domain} domain units must be "m" or "km" not {units}'
         if units is None:
             units = 'km'
     elif domain == 'extruded_spherical_shell':
@@ -106,6 +106,18 @@ def extract_gusto_coords(dataset, field_name, units=None):
         coords_X = dataset.variables[f'x_{coord_space}'][:]*unit_factor
         coords_Z = dataset.variables[f'z_{coord_space}'][:]*unit_factor
         return coords_X, coords_Z
+    elif domain == 'interval':
+        coords_X = dataset.variables[f'x_{coord_space}'][:]*unit_factor
+        return coords_X
+    elif domain == 'plane':
+        coords_X = dataset.variables[f'x_{coord_space}'][:]*unit_factor
+        coords_Y = dataset.variables[f'y_{coord_space}'][:]*unit_factor
+        return coords_X, coords_Y
+    elif domain == 'extruded_plane':
+        coords_X = dataset.variables[f'x_{coord_space}'][:]*unit_factor
+        coords_Y = dataset.variables[f'y_{coord_space}'][:]*unit_factor
+        coords_Z = dataset.variables[f'z_{coord_space}'][:]*unit_factor
+        return coords_X, coords_Y, coords_Z
     elif domain == 'extruded_spherical_shell':
         coords_X = dataset.variables[f'lon_{coord_space}'][:]*unit_factor
         coords_Y = dataset.variables[f'lat_{coord_space}'][:]*unit_factor

--- a/tomplot/tomplot_tools.py
+++ b/tomplot/tomplot_tools.py
@@ -44,7 +44,7 @@ def set_tomplot_style(fontsize=16, family='serif', usetex=True):
 
 
 def tomplot_field_title(ax, title, titlepad=None, return_title=False,
-                        fontsize=None, minmax=False, minmax_format='.2f',
+                        fontsize=None, minmax=False, minmax_format='default',
                         field_data=None):
     """
     Adds a title to a subplot, or generates a title to be returned depending on
@@ -83,8 +83,11 @@ def tomplot_field_title(ax, title, titlepad=None, return_title=False,
         field_min = np.min(field_data)
         field_max = np.max(field_data)
 
-        if minmax_format == '.2f' and (-abs(field_min) > 0.01 or abs(field_max) < 0.01):
-            minmax_format = '.2e'
+        if minmax_format == 'default':
+            if (-abs(field_min) > 0.01 or abs(field_max) < 0.01):
+                minmax_format = '.2e'
+            else:
+                minmax_format = '.2f'
 
         format_str = '{:'+minmax_format+'}'
 


### PR DESCRIPTION
This implements the remaining gusto domains (`plane`, `extruded plane` and `interval`), and improves the formatting used for including field mins and maxes in a title.