### PR TITLE
Local area function

### DIFF
--- a/tomplot/__init__.py
+++ b/tomplot/__init__.py
@@ -7,3 +7,4 @@ from tomplot.field_contour_plot import *                                  # noqa
 from tomplot.quiver_plot import *                                         # noqa
 from tomplot.regridding import *                                          # noqa
 from tomplot.tomplot_tools import *                                       # noqa
+from tomplot.local_area_plot import *                                     # noqa

--- a/tomplot/local_area_plot.py
+++ b/tomplot/local_area_plot.py
@@ -1,0 +1,40 @@
+import pandas as pd
+
+#TODO
+# Perhaps instead of an area function we could just call this plotting area and 
+# if no limits are passed it applied the gusto / lfric grid
+def area_restriction(field_data, coords_X, coords_Y,  Y_lim=None, X_lim=None):
+    """
+    a function that takes a data dictionary and will restrict it for a given value
+    For the coordinate fields you must pass in a 1d object so either coords[:,level]
+    for slicing on z or coords.flatten if slicing along lat / lon
+
+    args:
+    field_data: The Plotting field you wish to return 
+    coords_X: The coordinates you wish to plot along the X axis.
+    coords_Y: The field you wish to plot along the Y axis.
+    X_lim: tuple containing the (lower, upper) limits for the X axis
+    Y_lim: tuple containing the (lower, upper) limits for the Y axis
+    returns
+    restricted field data, X_coords, Y_coords
+    """
+    data_dict = {'field': field_data, 'X': coords_X, 'Y': coords_Y}
+    df = pd.DataFrame(data_dict) 
+    # ive used this logic to allow a user to only enter a limit for one axis
+    # and not have to use a new function, im sure there is a more elegant way
+    if not X_lim is None:
+        X_min, X_max = X_lim
+        df = df[(df["X"] >= X_min) & (df["X"] <= X_max)]
+
+    if not Y_lim is None:
+        Y_min, Y_max = Y_lim
+        df = df[(df["Y"] >= Y_min) & (df["Y"] <= Y_max)]
+        
+    new_field_data = df['field']
+    new_coords_X = df['X']
+    new_coords_Y = df['Y']
+
+    return (new_field_data, new_coords_X, new_coords_Y)
+
+    
+    

--- a/tomplot/local_area_plot.py
+++ b/tomplot/local_area_plot.py
@@ -1,16 +1,14 @@
 import pandas as pd
 
-#TODO
-# Perhaps instead of an area function we could just call this plotting area and 
-# if no limits are passed it applied the gusto / lfric grid
-def area_restriction(field_data, coords_X, coords_Y,  Y_lim=None, X_lim=None):
+
+def area_restriction(field_data, coords_X, coords_Y, Y_lim=None, X_lim=None):
     """
     a function that takes a data dictionary and will restrict it for a given value
     For the coordinate fields you must pass in a 1d object so either coords[:,level]
     for slicing on z or coords.flatten if slicing along lat / lon
 
     args:
-    field_data: The Plotting field you wish to return 
+    field_data: The Plotting field you wish to return
     coords_X: The coordinates you wish to plot along the X axis.
     coords_Y: The field you wish to plot along the Y axis.
     X_lim: tuple containing the (lower, upper) limits for the X axis
@@ -19,22 +17,19 @@ def area_restriction(field_data, coords_X, coords_Y,  Y_lim=None, X_lim=None):
     restricted field data, X_coords, Y_coords
     """
     data_dict = {'field': field_data, 'X': coords_X, 'Y': coords_Y}
-    df = pd.DataFrame(data_dict) 
+    df = pd.DataFrame(data_dict)
     # ive used this logic to allow a user to only enter a limit for one axis
     # and not have to use a new function, im sure there is a more elegant way
-    if not X_lim is None:
+    if X_lim is not None:
         X_min, X_max = X_lim
         df = df[(df["X"] >= X_min) & (df["X"] <= X_max)]
 
-    if not Y_lim is None:
+    if Y_lim is not None:
         Y_min, Y_max = Y_lim
         df = df[(df["Y"] >= Y_min) & (df["Y"] <= Y_max)]
-        
+
     new_field_data = df['field']
     new_coords_X = df['X']
     new_coords_Y = df['Y']
 
     return (new_field_data, new_coords_X, new_coords_Y)
-
-    
-    


### PR DESCRIPTION
A function named "area_restriction" has been created to restrict a plot to given ranges. This means users don't have to import pandas into their scripting script and mess around with that. 
I have tested it, slicing along lat, lon and z. 
The function also allows just one axis to be restricted 